### PR TITLE
Smaller icons of avatars images in result view

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
                 padding: 0 20px;
             }
             .wrapper #results img {
-                width: 44px;
-                height: 44px;
+                width: 2.4em;
+                height: 2.4em;
             }
             .conflicts {
                 color: red;


### PR DESCRIPTION
Due to big icons, the list was a bit blown up. With this change, the avatar height should match the list item height.